### PR TITLE
fix: prevent bpm value from getting lower than 1

### DIFF
--- a/demo/common.fe
+++ b/demo/common.fe
@@ -97,6 +97,10 @@
   (if (< n 0) (- 0 n) n)
 )
 
+(func max (n m)
+  (if (< n m) m n)
+)
+
 (func rev (lst)
   (let res nil)
   (while lst

--- a/demo/main.fe
+++ b/demo/main.fe
@@ -70,7 +70,7 @@
     (ui:row '(40 -1))
     (ui:label "Master") (ui:meter (abs (dsp:get master 'out)))
     (ui:row '(46 -1))
-    (ui:label "bpm:") (= bpm (ui:number "bpm" bpm))
+    (ui:label "bpm:") (= bpm (max 1 (ui:number "bpm" bpm)))
     (ui:row '(-1) 8)
     (ui:label "")
     (dsp:set-tick (bpm-to-seconds bpm))


### PR DESCRIPTION
bpm values lower than 1 produces an assertion failure

the same changes as #3

I didn't know that deleting the fork would close the pull request